### PR TITLE
Make database tests insensitive to the query part of the uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build
 out
 tasks.xml
 workspace.xml
+.classpath
+.project
+.settings
+

--- a/test-support/src/main/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperations.java
+++ b/test-support/src/main/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperations.java
@@ -61,7 +61,15 @@ final class RestOperationsTestOperations extends AbstractTestOperations {
 
     @Override
     public URI dataSourceUrl() {
-        return URI.create(this.restOperations.getForObject("http://{host}/datasource-url", String.class, this.host));
+        String uriString = this.restOperations.getForObject("http://{host}/datasource-url", String.class, this.host);
+        // depending on how uri is created, it may (when using spring-cloud) or may not (when using cloudfoundry-runtime) 
+        // have the query string with user credentials. So chop off any query parameters so that tests can verify the core
+        // part of the uri (host, port, etc.)
+        int queryStringStart = uriString.indexOf('?');
+        if (queryStringStart != -1) {
+            uriString = uriString.substring(0, queryStringStart);
+        }
+        return URI.create(uriString);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
There is a diffrence between spring-cloud and cloudfoundry-runtime on
how database url is created (and passed on the the driver). Transitively,
this affects auto-reconfig based on those libraries. This change removes
the query parameters from the url obtained throught REST call. This makes
the tests pass auto-reconfig tests before and after using spring-cloud.
