### PR TITLE
Change urls for datasource tests matching changes in test applications

### DIFF
--- a/test-support/src/main/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperations.java
+++ b/test-support/src/main/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperations.java
@@ -57,12 +57,12 @@ final class RestOperationsTestOperations extends AbstractTestOperations {
 
     @Override
     public String dataSourceCheckAccess() {
-        return this.restOperations.getForObject("http://{host}/datasource-check-access", String.class, this.host);
+        return this.restOperations.getForObject("http://{host}/datasource/check-access", String.class, this.host);
     }
 
     @Override
     public URI dataSourceUrl() {
-        String urlString = this.restOperations.getForObject("http://{host}/datasource-url", String.class, this.host);
+        String urlString = this.restOperations.getForObject("http://{host}/datasource/url", String.class, this.host);
         return JdbcUrlNormalizer.normalize(urlString);
     }
 

--- a/test-support/src/test/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperationsTest.java
+++ b/test-support/src/test/java/com/gopivotal/cloudfoundry/test/support/operations/RestOperationsTestOperationsTest.java
@@ -52,7 +52,7 @@ public final class RestOperationsTestOperationsTest {
 
     @Test
     public void dataSourceCheckAccess() throws Exception {
-        when(this.restOperations.getForObject("http://{host}/datasource-check-access", String.class,
+        when(this.restOperations.getForObject("http://{host}/datasource/check-access", String.class,
                 "test-host")).thenReturn("test-check-access");
 
         String value = this.testOperations.dataSourceCheckAccess();
@@ -63,7 +63,7 @@ public final class RestOperationsTestOperationsTest {
 
     @Test
     public void dataSourceUrl() throws Exception {
-        when(this.restOperations.getForObject("http://{host}/datasource-url", String.class,
+        when(this.restOperations.getForObject("http://{host}/datasource/url", String.class,
                 "test-host")).thenReturn("http://test.url");
 
         URI value = this.testOperations.dataSourceUrl();


### PR DESCRIPTION
To be used along with https://github.com/cloudfoundry/java-test-applications/pull/1
