### PR TITLE
Upgrade the Java Client to 1.0.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // All Project Configuration
 allprojects {
 	ext {
-		cloudFoundryClientLibVersion = '1.0.2'
+		cloudFoundryClientLibVersion = '1.0.5'
 		snakeyamlVersion = '1.14'
 		springBootVersion = '1.1.8.RELEASE'
 	}


### PR DESCRIPTION
This commit upgrades the version of the Java client used by the buildpack
system tests. The upgrade fixes several problems including a HTTP issue and
should result in much more stable system test runs.

See:
https://github.com/cloudfoundry/cf-java-client/issues/222
https://www.pivotaltracker.com/n/projects/816799/stories/78116662

[#79112530]
