### PR TITLE
Add distzip app to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The tests are extremely configurable allowing fine-grained control over what app
 
 ### Application Types:
 * `EJB`
+* `DISTZIP`
 * `GROOVY`
 * `JAVAMAIN`
 * `RATPACK`


### PR DESCRIPTION
The distzip app is not listed in Application Types