### PR TITLE
Select a lab pool for the latest lts version

### DIFF
--- a/ci/claim-environment.sh
+++ b/ci/claim-environment.sh
@@ -12,7 +12,7 @@ POOL_NAME=$(curl \
   --silent \
   --header 'Accept: application/json' \
   "https://environments.toolsmiths.cf-app.com/pool_names" \
-  | jq -r '.pool_names.gcp | map(select(contains("us"))) | last')
+  | jq -r '.pool_names.gcp | map(select(contains("us"))) | map(select(contains("lts"))) | .[]' | sort -Vr | head -1)
 
 printf "Claiming environment from %s\n" "${POOL_NAME}"
 


### PR DESCRIPTION
Previously, we would pick the latest version of CF we could get our hands on, however, under some situations this would result in getting a pool that's for a beta version of CF. This change filters only the LTS releases, so that we're guaranteed to get a valid pool and one that's likely popular across our user base.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>